### PR TITLE
feat(exception handling): Added local, global, custom exception handling

### DIFF
--- a/data/models.py
+++ b/data/models.py
@@ -28,15 +28,12 @@ class URL(Base):
     UserID = Column(Integer, ForeignKey("users.UserID"))
 
     def __repr__(self):
-        return (
-            "<URL(UserID='%s', EncodedURL='%s', OriginalURL='%s', CreationDate='%s', ExpirationDate='%s')>"
-            % (
-                self.UserID,
-                self.EncodedURL,
-                self.OriginalURL,
-                str(self.CreationDate),
-                str(self.ExpirationDate),
-            )
+        return "<URL(UserID='%s', EncodedURL='%s', OriginalURL='%s', CreationDate='%s', ExpirationDate='%s')>" % (
+            self.UserID,
+            self.EncodedURL,
+            self.OriginalURL,
+            str(self.CreationDate),
+            str(self.ExpirationDate),
         )
 
 
@@ -50,16 +47,13 @@ class USERS(Base):
     LastLogin = Column(DateTime, default=datetime.utcnow)
 
     def __repr__(self):
-        return (
-            "<User(UserID='%s', Name='%s', Email='%s', CreationDate='%s', LastLogin='%s', ApidevKey='%s')>"
-            % (
-                self.UserID,
-                self.Name,
-                self.Email,
-                str(self.CreationDate),
-                str(self.LastLogin),
-                self.ApiDevKey,
-            )
+        return "<User(UserID='%s', Name='%s', Email='%s', CreationDate='%s', LastLogin='%s', ApidevKey='%s')>" % (
+            self.UserID,
+            self.Name,
+            self.Email,
+            str(self.CreationDate),
+            str(self.LastLogin),
+            self.ApiDevKey,
         )
 
 

--- a/log_config.yaml
+++ b/log_config.yaml
@@ -11,7 +11,7 @@ handlers:
     stream: ext://sys.stdout
   file:
     class: logging.handlers.TimedRotatingFileHandler
-    level: ERROR
+    level: INFO
     formatter: default
     filename: turl.log
     backupCount: 4

--- a/tinyurl/exception_handling.py
+++ b/tinyurl/exception_handling.py
@@ -1,0 +1,46 @@
+from typing import Callable
+
+from fastapi import APIRouter, FastAPI, Request, Response
+from fastapi.exceptions import HTTPException
+from fastapi.responses import JSONResponse, Response
+from fastapi.routing import APIRoute
+
+from tinyurl.logging import turl_logger
+
+
+### Always raise one of these errors inside code
+class DataError(HTTPException):
+    def __init__(
+        self, status_code: int = 404, detail="Data not Found", headers=None
+    ) -> None:
+        ## If needed add headers here as well
+        super().__init__(status_code, detail=detail, headers=headers)
+
+
+### Handling Exception at global level in fastapi triggers Starlette Exception which doesn't give correct exception class, workaround by fastpapi devs
+# https://github.com/tiangolo/fastapi/issues/2750#issuecomment-775526951
+
+
+class ExceptionRoute(APIRoute):
+    def get_route_handler(self) -> Callable:
+        original_route_handler = super().get_route_handler()
+
+        async def custom_route_handler(request: Request):
+            try:
+                response: Response = await original_route_handler(request)
+            except Exception as err:
+                if isinstance(err, DataError):
+                    turl_logger.error(
+                        msg=err.detail, extra={"response_code": err.status_code}
+                    )
+                    return JSONResponse(
+                        content="Data Error: " + err.detail, status_code=err.status_code
+                    )
+                ## Add if any specific exception class needed.
+                else:
+                    turl_logger.error(msg=str(err), extra={"response_code": 500})
+                    return JSONResponse(
+                        content="Internal Server Error", status_code=500
+                    )
+
+        return custom_route_handler

--- a/tinyurl/keygen.py
+++ b/tinyurl/keygen.py
@@ -1,10 +1,13 @@
 from typing import Optional
 from uuid import uuid1
 
+from fastapi import HTTPException
 from hashids import Hashids
 
 from data.database import SQLiteSession
 from data.models import URL, USERS
+from tinyurl.exception_handling import DataError
+from tinyurl.logging import turl_logger
 
 MIN_LENGTH = 8
 
@@ -14,15 +17,16 @@ def get_username_id(api_dev_key: str) -> USERS:
     db_session = SQLiteSession().connection_string
     record = db_session.query(USERS).all()
     db_session.close()
-    if not record:
-        raise ValueError("Api Dev Key Record not Found")
+    if record:
+        raise DataError(detail="Api Dev Key Not found")
+
     return record[0]
 
 
 def generate_short_key(api_dev_key: str, original_url: str) -> str:
 
     if not api_dev_key or not original_url:
-        raise ValueError("Expected api_dev_key or Original URL to be not None")
+        raise DataError(detail="Expected api_dev_key or Original URL to be not None")
 
     salt = api_dev_key + original_url
 


### PR DESCRIPTION
feat(exception handling): Added local, global, custom exception handling

1. FastAPI has some issue with Starlette , where the global exception catch is not working but devs have a workaround for that. using same. [Can not capture the child class of "Exception" in app.exception_handler globally](https://github.com/tiangolo/fastapi/issues/2750#issuecomment-775526951)
2. To accommodate workaround global exception, had to update route definition according to the above issue. Else every time an error is thrown it is caught by Starlette Exception which is a low-level server exception.
3. Using Router functionality to define endpoints.
4. Updated Raise Exception, now we can raise custom exception
5. Log Level updated
6. PyType has a weird way of formatting the file again and again even it's already formatted. Which will be prioritized later.